### PR TITLE
Combined dependency updates (2022-12-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.5.2
+        uses: mikepenz/action-junit-report@v3.6.1
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<slf4j.version>2.0.3</slf4j.version>
+		<slf4j.version>2.0.5</slf4j.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.4.2</version>
+			<version>2.14.1</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.39.3.0</version>
+			<version>3.40.0.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.5.2 to 3.6.1](https://github.com/javiertuya/samples-test-java/pull/31)
- [Bump jackson-databind from 2.13.4.2 to 2.14.1](https://github.com/javiertuya/samples-test-java/pull/28)
- [Bump sqlite-jdbc from 3.39.3.0 to 3.40.0.0](https://github.com/javiertuya/samples-test-java/pull/29)
- [Bump slf4j.version from 2.0.3 to 2.0.5](https://github.com/javiertuya/samples-test-java/pull/32)