### PR TITLE
Combined dependency updates (2023-02-05)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3
       - name: Select Java Version
         uses: actions/setup-java@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.40.0.0</version>
+			<version>3.40.1.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.24</version>
+			<version>1.18.26</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- BEGINREDUCE -->

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.14.1</version>
+			<version>2.14.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Includes these updates:
- [Bump actions/configure-pages from 2 to 3](https://github.com/javiertuya/samples-test-java/pull/43)
- [Bump jackson-databind from 2.14.1 to 2.14.2](https://github.com/javiertuya/samples-test-java/pull/44)
- [Bump lombok from 1.18.24 to 1.18.26](https://github.com/javiertuya/samples-test-java/pull/46)
- [Bump sqlite-jdbc from 3.40.0.0 to 3.40.1.0](https://github.com/javiertuya/samples-test-java/pull/45)