### PR TITLE
Combined dependency updates (2023-02-18)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.1
+        uses: mikepenz/action-junit-report@v3.7.3
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
 			<plugin>
 				<groupId>org.jbehave</groupId>
 				<artifactId>jbehave-maven-plugin</artifactId>
-				<version>5.0</version>
+				<version>5.1</version>
 				<executions>
 					<!-- localizacion del mapping de historias y ejecucion en ut y en it -->
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.4.1</version>
+				<version>3.5.0</version>
 				<configuration>
 					<overview>${basedir}/src/main/java/overview.html</overview>
 					<sourcepath>${basedir}/src/main/java;${basedir}/src/test/java;${basedir}/src/it/java</sourcepath>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.1 to 3.7.3](https://github.com/javiertuya/samples-test-java/pull/52)
- [Bump maven-javadoc-plugin from 3.4.1 to 3.5.0](https://github.com/javiertuya/samples-test-java/pull/51)
- [Bump jbehave-maven-plugin from 5.0 to 5.1](https://github.com/javiertuya/samples-test-java/pull/49)