### PR TITLE
Combined dependency updates (2023-03-18)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0</version>
 				<configuration>
 					<testFailureIgnore>true</testFailureIgnore>
 					<!-- Sets the VM argument line used when unit tests are run under JaCoCo -->

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 		  <groupId>io.github.javiertuya</groupId>
 		  <artifactId>visual-assert</artifactId>
-		  <version>2.2.2</version>
+		  <version>2.3.0</version>
 		</dependency>
 
 		<!-- drivers de base de datos -->


### PR DESCRIPTION
Includes these updates:
- [Bump visual-assert from 2.2.2 to 2.3.0](https://github.com/javiertuya/samples-test-java/pull/58)
- [Bump maven-failsafe-plugin from 2.22.2 to 3.0.0](https://github.com/javiertuya/samples-test-java/pull/59)
- [Bump maven-surefire-plugin from 2.22.2 to 3.0.0](https://github.com/javiertuya/samples-test-java/pull/60)
- [Bump maven-surefire-report-plugin from 2.22.2 to 3.0.0](https://github.com/javiertuya/samples-test-java/pull/61)