### PR TITLE
Combined dependency updates (2023-03-26)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,4 +48,4 @@ jobs:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<slf4j.version>2.0.6</slf4j.version>
+		<slf4j.version>2.0.7</slf4j.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.3.1</version>
 				<executions>
 					<!-- copia del fuente de las historias a target para que se puedan localizar -->
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.41.0.0</version>
+			<version>3.41.2.1</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/deploy-pages from 1 to 2](https://github.com/javiertuya/samples-test-java/pull/63)
- [Bump maven-resources-plugin from 3.3.0 to 3.3.1](https://github.com/javiertuya/samples-test-java/pull/68)
- [Bump sqlite-jdbc from 3.41.0.0 to 3.41.2.1](https://github.com/javiertuya/samples-test-java/pull/67)
- [Bump slf4j.version from 2.0.6 to 2.0.7](https://github.com/javiertuya/samples-test-java/pull/64)