### PR TITLE
Combined dependency updates (2023-05-01)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.9</version>
+				<version>0.8.10</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.14.2</version>
+			<version>2.15.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Includes these updates:
- [Bump jackson-databind from 2.14.2 to 2.15.0](https://github.com/javiertuya/samples-test-java/pull/73)
- [Bump jacoco-maven-plugin from 0.8.9 to 0.8.10](https://github.com/javiertuya/samples-test-java/pull/74)