### PR TITLE
Combined dependency updates (2023-05-12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
 			<plugin>
 				<groupId>org.jbehave</groupId>
 				<artifactId>jbehave-maven-plugin</artifactId>
-				<version>5.1</version>
+				<version>5.1.1</version>
 				<executions>
 					<!-- localizacion del mapping de historias y ejecucion en ut y en it -->
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 				<configuration>
 					<testFailureIgnore>true</testFailureIgnore>
 					<!-- Sets the VM argument line used when unit tests are run under JaCoCo -->

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.4.0</version>
 				<executions>
 					<!-- ignorar error si eclipse senyala uno en este punto -->
 					<execution>


### PR DESCRIPTION
Includes these updates:
- [Bump maven-failsafe-plugin from 3.0.0 to 3.1.0](https://github.com/javiertuya/samples-test-java/pull/76)
- [Bump maven-surefire-plugin from 3.0.0 to 3.1.0](https://github.com/javiertuya/samples-test-java/pull/78)
- [Bump maven-surefire-report-plugin from 3.0.0 to 3.1.0](https://github.com/javiertuya/samples-test-java/pull/77)
- [Bump build-helper-maven-plugin from 3.3.0 to 3.4.0](https://github.com/javiertuya/samples-test-java/pull/79)
- [Bump jbehave-maven-plugin from 5.1 to 5.1.1](https://github.com/javiertuya/samples-test-java/pull/80)