### PR TITLE
Combined dependency updates (2023-05-28)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.6
+        uses: mikepenz/action-junit-report@v3.7.7
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.0</version>
+			<version>2.15.1</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.26</version>
+			<version>1.18.28</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- BEGINREDUCE -->


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.6 to 3.7.7](https://github.com/javiertuya/samples-test-java/pull/85)
- [Bump jackson-databind from 2.15.0 to 2.15.1](https://github.com/javiertuya/samples-test-java/pull/82)
- [Bump lombok from 1.18.26 to 1.18.28](https://github.com/javiertuya/samples-test-java/pull/86)