### PR TITLE
Combined dependency updates (2023-06-10)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.2</version>
 				<executions>
 					<execution>
 						<id>integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.1</version>
+			<version>2.15.2</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.2</version>
 				<configuration>
 					<testFailureIgnore>true</testFailureIgnore>
 					<!-- Sets the VM argument line used when unit tests are run under JaCoCo -->

--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.2</version>
 				<executions>
 					<execution>
 						<id>ut-reports</id>


### PR DESCRIPTION
Includes these updates:
- [Bump jackson-databind from 2.15.1 to 2.15.2](https://github.com/javiertuya/samples-test-java/pull/88)
- [Bump maven-failsafe-plugin from 3.1.0 to 3.1.2](https://github.com/javiertuya/samples-test-java/pull/90)
- [Bump maven-surefire-plugin from 3.1.0 to 3.1.2](https://github.com/javiertuya/samples-test-java/pull/91)
- [Bump maven-surefire-report-plugin from 3.1.0 to 3.1.2](https://github.com/javiertuya/samples-test-java/pull/89)