### PR TITLE
Combined dependency updates (2023-07-22)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build javadoc
         run: mvn install -DskipTests=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2.0.0
         with:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.0.0
+      - uses: javiertuya/sonarqube-action@v1.1.0
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.8
+        uses: mikepenz/action-junit-report@v3.8.0
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'


### PR DESCRIPTION
Includes these updates:
- [Bump actions/upload-pages-artifact from 1 to 2](https://github.com/javiertuya/samples-test-java/pull/97)
- [Bump javiertuya/sonarqube-action from 1.0.0 to 1.1.0](https://github.com/javiertuya/samples-test-java/pull/96)
- [Bump mikepenz/action-junit-report from 3.7.8 to 3.8.0](https://github.com/javiertuya/samples-test-java/pull/98)