### PR TITLE
Combined dependency updates (2023-09-23)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.28</version>
+			<version>1.18.30</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- BEGINREDUCE -->

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.6.0</version>
 				<configuration>
 					<overview>${basedir}/src/main/java/overview.html</overview>
 					<sourcepath>${basedir}/src/main/java;${basedir}/src/test/java;${basedir}/src/it/java</sourcepath>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>commons-dbutils</groupId>
 			<artifactId>commons-dbutils</artifactId>
-			<version>1.8.0</version>
+			<version>1.8.1</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-beanutils</groupId>


### PR DESCRIPTION
Includes these updates:
- [Bump commons-dbutils:commons-dbutils from 1.8.0 to 1.8.1](https://github.com/javiertuya/samples-test-java/pull/110)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.5.0 to 3.6.0](https://github.com/javiertuya/samples-test-java/pull/111)
- [Bump org.projectlombok:lombok from 1.18.28 to 1.18.30](https://github.com/javiertuya/samples-test-java/pull/112)