### PR TITLE
Combined dependency updates (2023-10-20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.1
+        uses: mikepenz/action-junit-report@v4.0.2
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.2</version>
+			<version>2.15.3</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.43.0.0</version>
+			<version>3.43.2.1</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.10</version>
+				<version>0.8.11</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 4.0.1 to 4.0.2](https://github.com/javiertuya/samples-test-java/pull/122)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.15.2 to 2.15.3](https://github.com/javiertuya/samples-test-java/pull/118)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.10 to 0.8.11](https://github.com/javiertuya/samples-test-java/pull/120)
- [Bump org.xerial:sqlite-jdbc from 3.43.0.0 to 3.43.2.1](https://github.com/javiertuya/samples-test-java/pull/121)