### PR TITLE
Combined dependency updates (2023-11-18)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.3</version>
+			<version>2.16.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.43.2.2</version>
+			<version>3.44.0.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<surefire.version>3.2.1</surefire.version>
+		<surefire.version>3.2.2</surefire.version>
 		<slf4j.version>2.0.9</slf4j.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.6.2</version>
 				<configuration>
 					<overview>${basedir}/src/main/java/overview.html</overview>
 					<sourcepath>${basedir}/src/main/java;${basedir}/src/test/java;${basedir}/src/it/java</sourcepath>


### PR DESCRIPTION
Includes these updates:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.15.3 to 2.16.0](https://github.com/javiertuya/samples-test-java/pull/131)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.6.0 to 3.6.2](https://github.com/javiertuya/samples-test-java/pull/130)
- [Bump org.xerial:sqlite-jdbc from 3.43.2.2 to 3.44.0.0](https://github.com/javiertuya/samples-test-java/pull/132)
- [Bump surefire.version from 3.2.1 to 3.2.2](https://github.com/javiertuya/samples-test-java/pull/129)