### PR TITLE
Combined dependency updates (2024-01-03)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,4 +48,4 @@ jobs:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3.0.1
+        uses: actions/deploy-pages@v4.0.2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build javadoc
         run: mvn install -DskipTests=true -Dmaven.test.failure.ignore=true -U --no-transfer-progress
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2.0.0
+        uses: actions/upload-pages-artifact@v3.0.0
         with:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.1.2
+      - uses: javiertuya/sonarqube-action@v1.2.0
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
  
       - if: always()
         name: Publish html test reports to an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports-files
           path: |
@@ -49,7 +49,7 @@ jobs:
             target/site/
       - if: always()
         name: Publish test reports for sonarqube job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports-for-sonar
           path: |

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.16.0</version>
+			<version>2.16.1</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<surefire.version>3.2.2</surefire.version>
-		<slf4j.version>2.0.9</slf4j.version>
+		<slf4j.version>2.0.10</slf4j.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/deploy-pages from 3.0.1 to 4.0.2](https://github.com/javiertuya/samples-test-java/pull/147)
- [Bump actions/upload-artifact from 3 to 4](https://github.com/javiertuya/samples-test-java/pull/148)
- [Bump actions/upload-pages-artifact from 2.0.0 to 3.0.0](https://github.com/javiertuya/samples-test-java/pull/146)
- [Bump javiertuya/sonarqube-action from 1.1.2 to 1.2.0](https://github.com/javiertuya/samples-test-java/pull/149)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.16.0 to 2.16.1](https://github.com/javiertuya/samples-test-java/pull/143)
- [Bump slf4j.version from 2.0.9 to 2.0.10](https://github.com/javiertuya/samples-test-java/pull/144)

Does not include these updates because of merge conflicts:
- [Bump surefire.version from 3.2.2 to 3.2.3](https://github.com/javiertuya/samples-test-java/pull/145)