### PR TITLE
Combined dependency updates (2024-04-01)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,4 +48,4 @@ jobs:
           path: 'target/site/testapidocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.4
+        uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Select Java Version
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.1.0
+        uses: mikepenz/action-junit-report@v4.2.1
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.3.0
+      - uses: javiertuya/sonarqube-action@v1.3.1
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.45.1.0</version>
+			<version>3.45.2.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.16.1</version>
+			<version>2.17.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
+			<version>1.18.32</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- BEGINREDUCE -->


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.projectlombok:lombok from 1.18.30 to 1.18.32](https://github.com/javiertuya/samples-test-java/pull/169)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.16.1 to 2.17.0](https://github.com/javiertuya/samples-test-java/pull/168)
- [Bump org.xerial:sqlite-jdbc from 3.45.1.0 to 3.45.2.0](https://github.com/javiertuya/samples-test-java/pull/167)
- [Bump javiertuya/sonarqube-action from 1.3.0 to 1.3.1](https://github.com/javiertuya/samples-test-java/pull/166)
- [Bump actions/deploy-pages from 4.0.4 to 4.0.5](https://github.com/javiertuya/samples-test-java/pull/165)
- [Bump mikepenz/action-junit-report from 4.1.0 to 4.2.1](https://github.com/javiertuya/samples-test-java/pull/164)
- [Bump actions/configure-pages from 4 to 5](https://github.com/javiertuya/samples-test-java/pull/163)