### PR TITLE
Combined dependency updates (2024-05-01)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.45.2.0</version>
+			<version>3.45.3.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.xerial:sqlite-jdbc from 3.45.2.0 to 3.45.3.0](https://github.com/javiertuya/samples-test-java/pull/173)
- [Bump slf4j.version from 2.0.12 to 2.0.13](https://github.com/javiertuya/samples-test-java/pull/172)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.11 to 0.8.12](https://github.com/javiertuya/samples-test-java/pull/171)