### PR TITLE
Combined dependency updates (2024-08-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.3.2
+      - uses: javiertuya/sonarqube-action@v1.4.0
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.0</version>
 				<configuration>
 					<overview>${basedir}/src/main/java/overview.html</overview>
 					<sourcepath>${basedir}/src/main/java;${basedir}/src/test/java;${basedir}/src/it/java</sourcepath>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
-		<surefire.version>3.3.0</surefire.version>
+		<surefire.version>3.3.1</surefire.version>
 		
 		<slf4j.version>2.0.13</slf4j.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.46.0.0</version>
+			<version>3.46.0.1</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.17.1</version>
+			<version>2.17.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.17.1 to 2.17.2](https://github.com/javiertuya/samples-test-java/pull/191)
- [Bump org.xerial:sqlite-jdbc from 3.46.0.0 to 3.46.0.1](https://github.com/javiertuya/samples-test-java/pull/190)
- [Bump surefire.version from 3.3.0 to 3.3.1](https://github.com/javiertuya/samples-test-java/pull/189)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.7.0 to 3.8.0](https://github.com/javiertuya/samples-test-java/pull/188)
- [Bump javiertuya/sonarqube-action from 1.3.2 to 1.4.0](https://github.com/javiertuya/samples-test-java/pull/187)