### PR TITLE
Combined dependency updates (2024-09-02)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 		  <groupId>io.github.javiertuya</groupId>
 		  <artifactId>visual-assert</artifactId>
-		  <version>2.4.2</version>
+		  <version>2.5.0</version>
 		</dependency>
 
 		<!-- drivers de base de datos -->


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump io.github.javiertuya:visual-assert from 2.4.2 to 2.5.0](https://github.com/javiertuya/samples-test-java/pull/198)
- [Bump surefire.version from 3.3.1 to 3.5.0](https://github.com/javiertuya/samples-test-java/pull/197)
- [Bump org.apache.ant:ant-junit from 1.10.14 to 1.10.15](https://github.com/javiertuya/samples-test-java/pull/196)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.10.0](https://github.com/javiertuya/samples-test-java/pull/195)
- [Bump org.xerial:sqlite-jdbc from 3.46.0.1 to 3.46.1.0](https://github.com/javiertuya/samples-test-java/pull/194)
- [Bump slf4j.version from 2.0.13 to 2.0.16](https://github.com/javiertuya/samples-test-java/pull/193)