### PR TITLE
Combined dependency updates (2025-02-07)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.48.0.0</version>
+			<version>3.49.0.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.xerial:sqlite-jdbc from 3.48.0.0 to 3.49.0.0](https://github.com/javiertuya/samples-test-java/pull/224)
- [Bump commons-beanutils:commons-beanutils from 1.9.4 to 1.10.0](https://github.com/javiertuya/samples-test-java/pull/222)