### PR TITLE
Combined dependency updates (2025-04-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v5.4.0
+        uses: mikepenz/action-junit-report@v5.5.1
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 		  <groupId>io.github.javiertuya</groupId>
 		  <artifactId>visual-assert</artifactId>
-		  <version>2.5.1</version>
+		  <version>2.6.0</version>
 		</dependency>
 
 		<!-- drivers de base de datos -->

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
-		<surefire.version>3.5.2</surefire.version>
+		<surefire.version>3.5.3</surefire.version>
 		
 		<slf4j.version>2.0.17</slf4j.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.36</version>
+			<version>1.18.38</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- BEGINREDUCE -->


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump io.github.javiertuya:visual-assert from 2.5.1 to 2.6.0](https://github.com/javiertuya/samples-test-java/pull/235)
- [Bump surefire.version from 3.5.2 to 3.5.3](https://github.com/javiertuya/samples-test-java/pull/234)
- [Bump org.projectlombok:lombok from 1.18.36 to 1.18.38](https://github.com/javiertuya/samples-test-java/pull/233)
- [Bump mikepenz/action-junit-report from 5.4.0 to 5.5.1](https://github.com/javiertuya/samples-test-java/pull/232)