### PR TITLE
Combined dependency updates (2025-05-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.4.1
+      - uses: javiertuya/sonarqube-action@v1.4.2
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.18.3</version>
+			<version>2.19.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.12</version>
+				<version>0.8.13</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.18.3 to 2.19.0](https://github.com/javiertuya/samples-test-java/pull/239)
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.12 to 0.8.13](https://github.com/javiertuya/samples-test-java/pull/238)
- [Bump javiertuya/sonarqube-action from 1.4.1 to 1.4.2](https://github.com/javiertuya/samples-test-java/pull/237)