### PR TITLE
Combined dependency updates (2025-07-01)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.0
+        uses: mikepenz/action-junit-report@v5.6.1
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.19.0</version>
+			<version>2.19.1</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.6.1</version>
 				<executions>
 					<!-- ignorar error si eclipse senyala uno en este punto -->
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.49.1.0</version>
+			<version>3.50.2.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 5.6.0 to 5.6.1](https://github.com/javiertuya/samples-test-java/pull/247)
- [Bump org.codehaus.mojo:build-helper-maven-plugin from 3.6.0 to 3.6.1](https://github.com/javiertuya/samples-test-java/pull/246)
- [Bump org.xerial:sqlite-jdbc from 3.49.1.0 to 3.50.2.0](https://github.com/javiertuya/samples-test-java/pull/245)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.19.0 to 2.19.1](https://github.com/javiertuya/samples-test-java/pull/244)