### PR TITLE
Combined dependency updates (2025-10-04)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
-		<surefire.version>3.5.3</surefire.version>
+		<surefire.version>3.5.4</surefire.version>
 		
 		<slf4j.version>2.0.17</slf4j.version>
 	</properties>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump surefire.version from 3.5.3 to 3.5.4](https://github.com/javiertuya/samples-test-java/pull/262)
- [Bump org.projectlombok:lombok from 1.18.38 to 1.18.42](https://github.com/javiertuya/samples-test-java/pull/261)
- [Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.11.3 to 3.12.0](https://github.com/javiertuya/samples-test-java/pull/260)