### PR TITLE
Combined dependency updates (2026-01-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
  
       - if: always()
         name: Publish html test reports to an artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: test-reports-files
           path: |
@@ -51,7 +51,7 @@ jobs:
 
       - if: always()
         name: Publish test reports for sonarqube job
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: test-reports-for-sonar
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v6.0.1
+        uses: mikepenz/action-junit-report@v6.1.0
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.4.3
+      - uses: javiertuya/sonarqube-action@v1.4.4
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/upload-artifact from 5 to 6](https://github.com/javiertuya/samples-test-java/pull/278)
- [Bump mikepenz/action-junit-report from 6.0.1 to 6.1.0](https://github.com/javiertuya/samples-test-java/pull/277)
- [Bump javiertuya/sonarqube-action from 1.4.3 to 1.4.4](https://github.com/javiertuya/samples-test-java/pull/276)