### PR TITLE
Combined dependency updates (2026-07-04)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Select Java Version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Publish surefire test report
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.1
+        uses: mikepenz/action-junit-report@v6.4.2
         with:
           check_name: test-report
           report_paths: 'target/*-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 10 #run tests under xvfb hangs sometimes, kills job if this happens
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.53.1.0</version>
+			<version>3.53.2.0</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.14</version>
+				<version>0.8.15</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TableColumnAdjuster.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
-		<junit.version>6.1.0</junit.version>
+		<junit.version>6.1.1</junit.version>
 		
 		<surefire.version>3.5.6</surefire.version>
 		

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<slf4j.version>2.0.18</slf4j.version>
 		
 		<!-- BEGINREDUCE -->
-		<cucumber.version>7.34.3</cucumber.version>
+		<cucumber.version>7.34.4</cucumber.version>
 		<!-- ENDREDUCE -->
 	</properties>
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.14 to 0.8.15](https://github.com/javiertuya/samples-test-java/pull/319)
- [Bump cucumber.version from 7.34.3 to 7.34.4](https://github.com/javiertuya/samples-test-java/pull/318)
- [Bump junit.version from 6.1.0 to 6.1.1](https://github.com/javiertuya/samples-test-java/pull/317)
- [Bump mikepenz/action-junit-report from 6.4.1 to 6.4.2](https://github.com/javiertuya/samples-test-java/pull/316)
- [Bump org.xerial:sqlite-jdbc from 3.53.1.0 to 3.53.2.0](https://github.com/javiertuya/samples-test-java/pull/315)
- [Bump actions/checkout from 6 to 7](https://github.com/javiertuya/samples-test-java/pull/314)