### PR TITLE
Combined dependency updates (2026-08-03)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Select Java Version
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v7
       - name: Select Java Version
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: javiertuya/sonarqube-action@v1.4.4
+      - uses: javiertuya/sonarqube-action@v1.4.5
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<slf4j.version>2.0.18</slf4j.version>
 		
 		<!-- BEGINREDUCE -->
-		<cucumber.version>7.34.4</cucumber.version>
+		<cucumber.version>7.34.6</cucumber.version>
 		<!-- ENDREDUCE -->
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.53.2.0</version>
+			<version>3.53.2.1</version>
 		</dependency>
 		<!-- Logs -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 		<dependency>
 		  <groupId>io.github.javiertuya</groupId>
 		  <artifactId>visual-assert</artifactId>
-		  <version>2.6.1</version>
+		  <version>2.6.2</version>
 		</dependency>
 
 		<!-- drivers de base de datos -->

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.21.3</version>
+			<version>2.22.1</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
-		<junit.version>6.1.1</junit.version>
+		<junit.version>6.1.2</junit.version>
 		
 		<surefire.version>3.5.6</surefire.version>
 		


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/setup-java from 5 to 5.6.0](https://github.com/javiertuya/samples-test-java/pull/328)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.21.3 to 2.22.1](https://github.com/javiertuya/samples-test-java/pull/327)
- [Bump org.xerial:sqlite-jdbc from 3.53.2.0 to 3.53.2.1](https://github.com/javiertuya/samples-test-java/pull/326)
- [Bump cucumber.version from 7.34.4 to 7.34.6](https://github.com/javiertuya/samples-test-java/pull/325)
- [Bump junit.version from 6.1.1 to 6.1.2](https://github.com/javiertuya/samples-test-java/pull/324)
- [Bump io.github.javiertuya:visual-assert from 2.6.1 to 2.6.2](https://github.com/javiertuya/samples-test-java/pull/323)
- [Bump javiertuya/sonarqube-action from 1.4.4 to 1.4.5](https://github.com/javiertuya/samples-test-java/pull/322)