### PR TITLE
ci: skip sonarqube on forked-repo PRs and dashgit branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,11 +64,13 @@ jobs:
   sonarqube:
     needs: [test]
     #if: ${{ false }}  # disable for now
-    # Cuando viene de una PR de dependabot este job falla porque no puede leer el token de sonarqube
-    # (restriccion de seguridad de GitHub Actions). Discusion y workarounds:
+    # Cuando viene de una PR de dependabot o de un repo forkeado este job falla porque no puede
+    # leer el token de sonarqube (restriccion de seguridad de GitHub Actions). Discusion y workarounds:
     # https://community.sonarsource.com/t/youre-not-authorized-to-run-analysis-and-github-bots/41994/4
     # https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    # Tampoco se ejecuta en las ramas combinadas por dashgit, que solo contienen cambios de version
+    if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork
+      && !startsWith(github.ref, 'refs/heads/dashgit/combined/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: javiertuya/sonarqube-action@v1.4.5


### PR DESCRIPTION
The sonarqube job could not read SONAR_TOKEN on PRs coming from a fork, and it
was analysing branches that only contain dependency version bumps.

- exclude forked-repo PRs from the sonarqube job, in addition to dependabot
- exclude pushes to the dashgit/combined/** branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
